### PR TITLE
feat: add configurable default prompt value setting

### DIFF
--- a/src/PluginSettings.ts
+++ b/src/PluginSettings.ts
@@ -73,6 +73,8 @@ export class PluginSettings {
   public moveAttachmentToProperFolderUsedByMultipleNotesMode: MoveAttachmentToProperFolderUsedByMultipleNotesMode =
     MoveAttachmentToProperFolderUsedByMultipleNotesMode.CopyAll;
 
+  public promptDefaultValue = '';
+
   public renamedAttachmentFileName = '';
   public shouldDeleteOrphanAttachments = false;
   public shouldHandleRenames = true;

--- a/src/PluginSettingsTab.ts
+++ b/src/PluginSettingsTab.ts
@@ -121,6 +121,34 @@ export class PluginSettingsTab extends PluginSettingsTabBase<PluginTypes> {
       });
 
     new SettingEx(this.containerEl)
+      .setName(t(($) => $.pluginSettingsTab.promptDefaultValue.name))
+      .setDesc(createFragment((f) => {
+        f.appendText(t(($) => $.pluginSettingsTab.promptDefaultValue.description.part1));
+        f.createEl('br');
+        f.appendText(t(($) => $.pluginSettingsTab.promptDefaultValue.description.part2));
+        f.appendText(' ');
+        // eslint-disable-next-line no-template-curly-in-string -- Valid token.
+        appendCodeBlock(f, '${originalAttachmentFileName}');
+        f.appendText(' ');
+        f.appendText(t(($) => $.pluginSettingsTab.promptDefaultValue.description.part3));
+      }))
+      .addCodeHighlighter((codeHighlighter) => {
+        codeHighlighter.setLanguage(TOKENIZED_STRING_LANGUAGE);
+        codeHighlighter.inputEl.addClass('tokenized-string-setting-control');
+        this.bind(codeHighlighter, 'promptDefaultValue', {
+          componentToPluginSettingsValueConverter(uiValue: string): string {
+            const trimmed = uiValue.trimEnd();
+            return trimmed === '' ? '' : normalizePath(trimmed);
+          },
+          pluginSettingsToComponentValueConverter(pluginSettingsValue: string): string {
+            return pluginSettingsValue.trimEnd();
+          },
+          shouldResetSettingWhenComponentIsEmpty: false,
+          shouldShowPlaceholderForDefaultValues: false
+        });
+      });
+
+    new SettingEx(this.containerEl)
       .setName(t(($) => $.pluginSettingsTab.attachmentRenameMode.name))
       .setDesc(createFragment((f) => {
         f.appendText(t(($) => $.pluginSettingsTab.attachmentRenameMode.description.part1));

--- a/src/PromptWithPreviewModal.ts
+++ b/src/PromptWithPreviewModal.ts
@@ -19,6 +19,7 @@ import type { TokenEvaluatorContext } from './TokenEvaluatorContext.ts';
 
 interface PromptWithPreviewModalOptions {
   ctx: TokenEvaluatorContext;
+  defaultValue: string;
   valueValidator: (value: string) => Promise<null | string>;
 }
 
@@ -79,7 +80,7 @@ class PromptWithPreviewModal extends Modal {
   public constructor(private readonly options: PromptWithPreviewModalOptions, private readonly resolve: PromiseResolve<null | string>) {
     super(options.ctx.app);
     addPluginCssClasses(this.containerEl, CssClass.PromptModal);
-    this.value = options.ctx.originalAttachmentFileName;
+    this.value = options.defaultValue;
   }
 
   public override onClose(): void {

--- a/src/i18n/locales/default.ts
+++ b/src/i18n/locales/default.ts
@@ -344,6 +344,14 @@ export const defaultTranslations = {
       },
       name: 'Move attachment to proper folder used by multiple notes mode'
     },
+    promptDefaultValue: {
+      description: {
+        part1: 'Default value shown in the prompt dialog. Leave empty to start with a blank field.',
+        part2: 'Use',
+        part3: 'to pre-fill with the original filename.'
+      },
+      name: 'Default prompt value'
+    },
     renameAttachmentsToLowerCase: 'Rename attachments to lower case',
     renamedAttachmentFileName: {
       description: {


### PR DESCRIPTION
Add a new "Default prompt value" setting that allows users to configure what value is pre-filled in the ${prompt} dialog when pasting attachments.

- Supports leaving empty for a blank prompt field (previously showed filename every time)
- Use ${originalAttachmentFileName} to pre-fill with the original filename

<img width="1091" height="670" alt="image" src="https://github.com/user-attachments/assets/24066512-24e3-4ac4-a196-be34b0148329" />

<img width="637" height="241" alt="image" src="https://github.com/user-attachments/assets/abaea4a0-dbb7-4fb9-8848-8342fb46bd9e" />
